### PR TITLE
`odcast` => `podcast`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A curated list of podcasts we like to listen to.
 * [ShopTalk Show](http://shoptalkshow.com) - Podcast about front end web design, development and UX.
 * [Between Screens](https://soundcloud.com/between-screens) - Expect to find content about the following topics: Ruby, Rails, Sinatra, Sass, Javascript, Design Patterns, Jekyll, Client-Side Web Apps, Rust, Typography, Git, Responsive Design, Prototyping, Web Design, Type Design and more …
 * [Developer Tea](https://developertea.com) - Podcast for web and software developers hosted by a developer that you can listen to in less than 10 minutes.
-* [The Cognicast](http://blog.cognitect.com/cognicast) - The Cognicast previously ThinkRelevance: The Podcast is the odcast from the Cognitect family.
+* [The Cognicast](http://blog.cognitect.com/cognicast) - The Cognicast previously ThinkRelevance: The Podcast is the podcast from the Cognitect family.
 * [Functional Geekery](http://www.functionalgeekery.com) - Functional Geeks, Geeking Functionally.
 * [Ruby Rogues](http://devchat.tv/ruby-rogues)
 * [Ruby5](https://ruby5.codeschool.com) - The latest news in the Ruby and Rails community.


### PR DESCRIPTION
Typo I guess.
